### PR TITLE
Fix duplicate tests names

### DIFF
--- a/tests/pep492/test_492.py
+++ b/tests/pep492/test_492.py
@@ -31,7 +31,7 @@ async def test_await_read_lock(loop):
 
 
 @pytest.mark.run_loop
-async def test_write_context_manager(loop):
+async def test_await_write_lock(loop):
     rwlock = RWLock(loop=loop)
     writer = rwlock.writer_lock
     assert not writer.locked


### PR DESCRIPTION
Two tests have same name, as result first one is never executed. 