### PR TITLE
fix function _RWLockCore._wake_up can only wake up one reader once

### DIFF
--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -165,16 +165,16 @@ class _RWLockCore:
         self._wake_up()
 
     def _wake_up(self):
-        '''
-        If no one is reading or writing, wake up write waiters first, only one write waiter should be waken up, 
-        if no write waiters and have read waiters, wake up all read waiters.
+        '''If no one is reading or writing, wake up write waiters
+        first, only one write waiter should be waken up, if no
+        write waiters and have read waiters, wake up all read waiters.
         '''
         if self._r_state == 0 and self._w_state == 0:
             if self._write_waiters:
-                #Wake up one write writer only
+                # Only wake up one write writer
                 self._wake_up_first(self._write_waiters)
             elif self._read_waiters:
-                #Wake up all read waiters
+                # Wake up all read waiters
                 self._wake_up_all(self._read_waiters)
 
     def _wake_up_first(self, waiters):
@@ -183,11 +183,13 @@ class _RWLockCore:
             if not fut.done():
                 fut.set_result(None)
                 break
-
+    
     def _wake_up_all(self, waiters):
+        '''Wake up all waiters'''
         for fut in waiters:
             if not fut.done():
                 fut.set_result(None)
+
 
 class _ContextManagerMixin:
 

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -165,10 +165,10 @@ class _RWLockCore:
         self._wake_up()
 
     def _wake_up(self):
-        '''If no one is reading or writing, wake up write waiters
+        """If no one is reading or writing, wake up write waiters
         first, only one write waiter should be waken up, if no
         write waiters and have read waiters, wake up all read waiters.
-        '''
+        """
         if self._r_state == 0 and self._w_state == 0:
             if self._write_waiters:
                 # Only wake up one write writer
@@ -185,7 +185,7 @@ class _RWLockCore:
                 break
 
     def _wake_up_all(self, waiters):
-        '''Wake up all waiters'''
+        """Wake up all waiters."""
         for fut in waiters:
             if not fut.done():
                 fut.set_result(None)

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -183,7 +183,7 @@ class _RWLockCore:
             if not fut.done():
                 fut.set_result(None)
                 break
-    
+ 
     def _wake_up_all(self, waiters):
         '''Wake up all waiters'''
         for fut in waiters:

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -183,7 +183,7 @@ class _RWLockCore:
             if not fut.done():
                 fut.set_result(None)
                 break
- 
+
     def _wake_up_all(self, waiters):
         '''Wake up all waiters'''
         for fut in waiters:

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -165,16 +165,14 @@ class _RWLockCore:
         self._wake_up()
 
     def _wake_up(self):
-        """If no one is reading or writing, wake up write waiters
-        first, only one write waiter should be waken up, if no
-        write waiters and have read waiters, wake up all read waiters.
-        """
+        # If no one is reading or writing, wake up write waiters
+        # first, only one write waiter should be waken up, if no
+        # write waiters and have read waiters, wake up all read 
+        # waiters.
         if self._r_state == 0 and self._w_state == 0:
             if self._write_waiters:
-                # Only wake up one write writer
                 self._wake_up_first(self._write_waiters)
             elif self._read_waiters:
-                # Wake up all read waiters
                 self._wake_up_all(self._read_waiters)
 
     def _wake_up_first(self, waiters):

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -167,7 +167,7 @@ class _RWLockCore:
     def _wake_up(self):
         # If no one is reading or writing, wake up write waiters
         # first, only one write waiter should be waken up, if no
-        # write waiters and have read waiters, wake up all read 
+        # write waiters and have read waiters, wake up all read
         # waiters.
         if self._r_state == 0 and self._w_state == 0:
             if self._write_waiters:


### PR DESCRIPTION
In function `_RWLockCore._wake_up`, the code shows can only wake up one reader once, I think it's not right, I think should  wake up all readers once if can get read lock, because write-lock is exclusive-lock, and read-lock is shared-lock.