### PR TITLE
Better assert

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
 bandit==1.5.1
-flake8-bugbear==18.8.0
+flake8-bugbear==19.3.0
 flake8-quotes==1.0.0
 flake8==3.7.7
 pyroma==2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ flake8==3.7.7
 pyroma==2.4
 pytest-cov==2.6.1
 pytest==4.4.0
-uvloop==0.12.1
+uvloop==0.12.2
 mypy==0.670

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ flake8-quotes==1.0.0
 flake8==3.7.7
 pyroma==2.4
 pytest-cov==2.6.1
-pytest==4.3.0
+pytest==4.4.0
 uvloop==0.12.1
 mypy==0.670

--- a/tests/test_corner_cases.py
+++ b/tests/test_corner_cases.py
@@ -19,7 +19,8 @@ def should_fail(timeout, loop):
         handle.cancel()
         return
     else:
-        raise AssertionError('Inner task expected to be cancelled', task)
+        msg = 'Inner task expected to be cancelled: {}'.format(task)
+        pytest.fail(msg)
 
 
 @pytest.mark.run_loop

--- a/tests/test_corner_cases.py
+++ b/tests/test_corner_cases.py
@@ -19,7 +19,7 @@ def should_fail(timeout, loop):
         handle.cancel()
         return
     else:
-        assert False, ('Inner task expected to be cancelled', task)
+        raise AssertionError('Inner task expected to be cancelled', task)
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
Fixes lint issue:
` Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError()`