### PR TITLE
Add cfg file for TLA+ spec and prevent TLC from reporting a deadlock

### DIFF
--- a/spec/aiorwlock.cfg
+++ b/spec/aiorwlock.cfg
@@ -6,3 +6,4 @@ CONSTANTS
 
 INVARIANTS
     LockInv
+    TypeOK

--- a/spec/aiorwlock.cfg
+++ b/spec/aiorwlock.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION
+    Spec
+
+CONSTANTS
+    Task = {t1, t2}
+
+INVARIANTS
+    LockInv

--- a/spec/aiorwlock.tla
+++ b/spec/aiorwlock.tla
@@ -51,9 +51,14 @@ WRelease(t) == \/ /\ Wlocked /\ Lock[t] = "Write"
                \/ /\ Wlocked /\ Lock[t] = "WriteRead"
                   /\ WState' = WState - 1 /\ Lock' = [Lock EXCEPT ![t] = "Read"]
                   /\ UNCHANGED RState
+
+
+(* Allow infinite stuttering to prevent deadlock. *)
+Finished == /\ \A t \in Task: Lock[t] = "Finished"
+            /\ UNCHANGED <<RState, WState, Lock>>
 -----------------------------------------------------------------------------
 
-Next == \E t \in Task: RAquire(t) \/ WAquire(t) \/ RRelease(t) \/ WRelease(t)
+Next == \E t \in Task: RAquire(t) \/ WAquire(t) \/ RRelease(t) \/ WRelease(t) \/ Finished
 
 Spec == LockInit /\ [][Next]_<<RState, WState, Lock>>
 


### PR DESCRIPTION
Allow stuttering after all tasks have finished, since TLC can not distinguish this from a deadlock.

Closes #131