### PR TITLE
Add a note about acquiring/releasing by the same task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,9 @@ frequently searched is an ideal candidate for the use of a read-write lock.
 However, if updates become frequent then the data spends most of its time
 being exclusively locked and there is little, if any increase in concurrency.
 
+**Note:** a task that *acquires* the lock should be used for *releasing* it.
+Locking from one task and releasing from another one generates ``RuntimeError``.
+
 
 Implementation is almost direct port from this patch_.
 

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -3,7 +3,7 @@ import threading
 from collections import deque
 from typing import Any, Deque, List, Tuple
 
-__version__ = "1.4.0"
+__version__ = "1.5.0a0"
 __all__ = ('RWLock',)
 
 

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -3,11 +3,7 @@ import threading
 from collections import deque
 from typing import Any, Deque, List, Tuple
 
-__all__ = ('RWLock',)
-
-
-def __dir__() -> tuple[str, ...]:
-    return __all__ + ('__version__',)
+__all__ = ('RWLock', '__version__')
 
 
 def __getattr__(name: str) -> object:
@@ -16,8 +12,8 @@ def __getattr__(name: str) -> object:
     if name == "__version__":
         from importlib.metadata import version
 
-        __version__ = version("aiorwlock")
-        return __version__
+        ver = __version__ = version("aiorwlock")  # type: ignore[name-defined]
+        return ver
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -3,7 +3,11 @@ import threading
 from collections import deque
 from typing import Any, Deque, List, Tuple
 
-__all__ = ('RWLock', '__version__')
+__all__ = ('RWLock',)
+
+
+def __dir__() -> tuple[str, ...]:
+    return __all__ + ('__version__',)
 
 
 def __getattr__(name: str) -> object:

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -11,6 +11,7 @@ def __getattr__(name: str) -> object:
 
     if name == "__version__":
         from importlib.metadata import version
+
         __version__ = version("aiorwlock")
         return __version__
 

--- a/aiorwlock/__init__.py
+++ b/aiorwlock/__init__.py
@@ -145,8 +145,8 @@ class _RWLockCore:
 
         try:
             self._owning.remove((me, lock_type))
-        except ValueError:
-            raise RuntimeError('Cannot release an un-acquired lock')
+        except ValueError as exc:
+            raise RuntimeError('Cannot release an un-acquired lock') from exc
         if lock_type == self._RL:
             self._r_state -= 1
         else:


### PR DESCRIPTION
Also, `raise RuntimeError()` is replaced with `raise RuntimeError() from exc` for better traceback generation.
